### PR TITLE
Fix/detect secrets hook soften

### DIFF
--- a/__tests__/executeStrategy.test.js
+++ b/__tests__/executeStrategy.test.js
@@ -29,7 +29,9 @@ describe('Strategies: executeStrategy', () => {
 
     ChildProcess.spawnSync = jest.fn(() => {
       return {
-        status: 0
+        status: 0,
+        stdout: '',
+        stderr: ''
       }
     })
 
@@ -52,7 +54,9 @@ describe('Strategies: executeStrategy', () => {
 
     ChildProcess.spawnSync = jest.fn(() => {
       return {
-        status: 1
+        status: 1,
+        stdout: '',
+        stderr: ''
       }
     })
 

--- a/src/strategies.js
+++ b/src/strategies.js
@@ -36,9 +36,19 @@ function executeStrategy(strategy) {
   }
 
   const spawnResult = ChildProcess.spawnSync(strategy.filePath, hookCommandArguments, {
-    stdio: 'inherit',
     shell: true
   })
+
+  console.log(spawnResult.stdout.toString('utf-8'))
+  console.error(spawnResult.stderr.toString('utf-8'))
+
+  const stderr = spawnResult.stderr.toString('utf-8')
+  const stringFound = stderr.match(/The baseline file was updated/g)
+  if (stringFound) {
+    // force a 0 status code as this isn't an actual error
+    // ref: https://github.com/Yelp/detect-secrets/issues/212
+    return 0
+  }
 
   return spawnResult.status
 }


### PR DESCRIPTION
## Description

Force updates to the secrets baseline file to exit successfully and now throw a command line error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

See https://github.com/Yelp/detect-secrets/issues/212 for more context


