### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="https://www.npmjs.org/package/detect-secrets"><img src="https://badgen.net/npm/dt/detect-secrets" alt="downloads"/></a>
   <a href="https://travis-ci.org/lirantal/detect-secrets"><img src="https://badgen.net/travis/lirantal/detect-secrets" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/detect-secrets"><img src="https://badgen.net/codecov/c/github/lirantal/detect-secrets" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/detect-secrets"><img src="https://snyk.io/test/github/lirantal/detect-secrets/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Security Responsible Disclosure" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.